### PR TITLE
Add a 'show_position' parameter, which hides lineno and colno when set to False.

### DIFF
--- a/astpretty.py
+++ b/astpretty.py
@@ -26,11 +26,11 @@ def _is_leaf(node):
         return True
 
 
-def pformat(node, indent='    ', _indent=0):
+def pformat(node, indent='    ', show_offsets=True, _indent=0):
     if node is None:  # pragma: no cover (py35+ unpacking in literals)
         return repr(node)
     elif _is_leaf(node):
-        if hasattr(node, 'lineno'):
+        if show_offsets and hasattr(node, 'lineno'):
             ret = ast.dump(node)
             # For nodes like Pass() which have information but no data
             if ret.endswith('()'):
@@ -58,11 +58,14 @@ def pformat(node, indent='    ', _indent=0):
             return state.indent * indent
 
         def _pformat(el, _indent=0):
-            return pformat(el, indent=indent, _indent=_indent)
+            return pformat(
+                el, indent=indent, show_offsets=show_offsets,
+                _indent=_indent,
+            )
 
         out = type(node).__name__ + '(\n'
         with indented():
-            if hasattr(node, 'lineno'):
+            if show_offsets and hasattr(node, 'lineno'):
                 fields = ('lineno', 'col_offset') + node._fields
             else:
                 fields = node._fields
@@ -102,11 +105,15 @@ def pprint(*args, **kwargs):
 def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('filename')
+    parser.add_argument(
+        '--no-show-offsets', dest='show_offsets',
+        action='store_false',
+    )
     args = parser.parse_args(argv)
 
     with open(args.filename, 'rb') as f:
         contents = f.read()
-    pprint(ast.parse(contents))
+    pprint(ast.parse(contents), show_offsets=args.show_offsets)
 
 
 if __name__ == '__main__':

--- a/tests/astpretty_test.py
+++ b/tests/astpretty_test.py
@@ -67,6 +67,16 @@ def test_pformat_nested():
     )
 
 
+def test_pformat_nested_no_offsets():
+    ret = astpretty.pformat(_to_module_body('x = 5'), show_offsets=False)
+    assert ret == (
+        'Assign(\n'
+        "    targets=[Name(id='x', ctx=Store())],\n"
+        '    value=Num(n=5),\n'
+        ')'
+    )
+
+
 def test_pformat_nested_attr_empty_list():
     ret = astpretty.pformat(_to_module_body('if 1: pass'))
     assert ret == (
@@ -159,6 +169,23 @@ Module(
             col_offset=0,
             targets=[Name(lineno=1, col_offset=0, id='x', ctx=Store())],
             value=Num(lineno=1, col_offset=4, n=5),
+        ),
+    ],
+)
+'''
+
+
+def test_main_hide_offsets(capsys, tmpdir):
+    f = tmpdir.join('test.py')
+    f.write('x = 5\n')
+    astpretty.main((f.strpath, '--no-show-offsets'))
+    out, _ = capsys.readouterr()
+    assert out == '''\
+Module(
+    body=[
+        Assign(
+            targets=[Name(id='x', ctx=Store())],
+            value=Num(n=5),
         ),
     ],
 )


### PR DESCRIPTION
Use case: I want to compare the ASTs of two Python files but ignore changes in line breaks.

PS: thanks for writing this lib, it's very useful when using `diff -u`! It's a shame `ast.dump` does not have an option to do that.