### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,12 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/astpretty.py
+++ b/astpretty.py
@@ -1,13 +1,12 @@
+from __future__ import annotations
+
 import argparse
 import ast
 import contextlib
 import sys
 from typing import Any
 from typing import Generator
-from typing import Optional
 from typing import Sequence
-from typing import Tuple
-from typing import Type
 from typing import TYPE_CHECKING
 from typing import Union
 
@@ -16,8 +15,8 @@ if TYPE_CHECKING:
     from typed_ast import ast3
     ASTType = Union[ast.AST, ast27.AST, ast3.AST]
 
-AST: Tuple[Type[Any], ...] = (ast.AST,)
-expr_context: Tuple[Type[Any], ...] = (ast.expr_context,)
+AST: tuple[type[Any], ...] = (ast.AST,)
+expr_context: tuple[type[Any], ...] = (ast.expr_context,)
 try:  # pragma: no cover (with typed-ast)
     from typed_ast import ast27
     from typed_ast import ast3
@@ -33,7 +32,7 @@ def _is_sub_node(node: object) -> bool:
     return isinstance(node, AST) and not isinstance(node, expr_context)
 
 
-def _is_leaf(node: 'ASTType') -> bool:
+def _is_leaf(node: ASTType) -> bool:
     for field in node._fields:
         attr = getattr(node, field)
         if _is_sub_node(attr):
@@ -46,14 +45,14 @@ def _is_leaf(node: 'ASTType') -> bool:
         return True
 
 
-def _fields(n: 'ASTType', show_offsets: bool = True) -> Tuple[str, ...]:
+def _fields(n: ASTType, show_offsets: bool = True) -> tuple[str, ...]:
     if show_offsets:
         return n._attributes + n._fields
     else:
         return n._fields
 
 
-def _leaf(node: 'ASTType', show_offsets: bool = True) -> str:
+def _leaf(node: ASTType, show_offsets: bool = True) -> str:
     if isinstance(node, AST):
         return '{}({})'.format(
             type(node).__name__,
@@ -74,8 +73,8 @@ def _leaf(node: 'ASTType', show_offsets: bool = True) -> str:
 
 
 def pformat(
-        node: Union['ASTType', None, str],
-        indent: Union[str, int] = '    ',
+        node: ASTType | None | str,
+        indent: str | int = '    ',
         show_offsets: bool = True,
         _indent: int = 0,
 ) -> str:
@@ -103,7 +102,7 @@ def pformat(
         def indentstr() -> str:
             return state.indent * indent_s
 
-        def _pformat(el: Union['ASTType', None, str], _indent: int = 0) -> str:
+        def _pformat(el: ASTType | None | str, _indent: int = 0) -> str:
             return pformat(
                 el, indent=indent, show_offsets=show_offsets,
                 _indent=_indent,
@@ -143,7 +142,7 @@ def pprint(*args: Any, **kwargs: Any) -> None:
     print(pformat(*args, **kwargs))
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filename')
     parser.add_argument(

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38, py39]
+    toxenvs: [py37, py38, py39]
     os: linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -23,7 +22,7 @@ classifiers =
 
 [options]
 py_modules = astpretty
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/astpretty_test.py
+++ b/tests/astpretty_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import sys
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos